### PR TITLE
Correct tree depth computation

### DIFF
--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -68,8 +68,7 @@ const HTriangular = Union{HLowerTriangular,HUpperTriangular}
 # NOTE: parent here refers to the underlying data of the view, NOT the
 # parentnode. Ducktype and hope for the best.
 hasdata(H) = !isnothing(data(parent(H)))
-isroot(H) = parent(H) === H
-isrootnode(H) = H.parentnode === H
+isroot(H) = parentnode(H) === H
 rowrange(H) = index_range(rowtree(H))
 colrange(H) = index_range(coltree(H))
 rowperm(H) = loc2glob(rowtree(H))

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -68,7 +68,7 @@ const HTriangular = Union{HLowerTriangular,HUpperTriangular}
 # NOTE: parent here refers to the underlying data of the view, NOT the
 # parentnode. Ducktype and hope for the best.
 hasdata(H) = !isnothing(data(parent(H)))
-isroot(H) = parent(H) === H
+isroot(H) = H.parentnode === H
 rowrange(H) = index_range(rowtree(H))
 colrange(H) = index_range(coltree(H))
 rowperm(H) = loc2glob(rowtree(H))

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -68,7 +68,8 @@ const HTriangular = Union{HLowerTriangular,HUpperTriangular}
 # NOTE: parent here refers to the underlying data of the view, NOT the
 # parentnode. Ducktype and hope for the best.
 hasdata(H) = !isnothing(data(parent(H)))
-isroot(H) = H.parentnode === H
+isroot(H) = parent(H) === H
+isrootnode(H) = H.parentnode === H
 rowrange(H) = index_range(rowtree(H))
 colrange(H) = index_range(coltree(H))
 rowperm(H) = loc2glob(rowtree(H))
@@ -155,8 +156,8 @@ function _show(io, hmat, allow_empty = false)
     points_per_leaf = map(length, leaves_)
     @printf(io, "\n\t min number of elements per leaf: %i", minimum(points_per_leaf))
     @printf(io, "\n\t max number of elements per leaf: %i", maximum(points_per_leaf))
-    depth_per_leaf = map(depth, leaves_)
-    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_leaf))
+    depth_per_node = map(depth, nodes_)
+    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_node))
     @printf(io, "\n\t compression ratio: %f\n", compression_ratio(hmat))
     return io
 end

--- a/src/hmatrix.jl
+++ b/src/hmatrix.jl
@@ -156,8 +156,8 @@ function _show(io, hmat, allow_empty = false)
     points_per_leaf = map(length, leaves_)
     @printf(io, "\n\t min number of elements per leaf: %i", minimum(points_per_leaf))
     @printf(io, "\n\t max number of elements per leaf: %i", maximum(points_per_leaf))
-    depth_per_node = map(depth, nodes_)
-    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_node))
+    depth_per_leaf = map(depth, leaves_)
+    @printf(io, "\n\t depth of tree: %i", maximum(depth_per_leaf))
     @printf(io, "\n\t compression ratio: %f\n", compression_ratio(hmat))
     return io
 end

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -24,7 +24,6 @@ function hmul!(
     else
         bufs_
     end
-    @assert isroot(C) || !hasdata(parent(C))
     b == true || rmul!(C, b)
     dict = IdDict{T,Vector{Tuple{eltype(children(A)),eltype(children(B))}}}()
     _plan_dict!(dict, C, A, B, Cflag)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -82,7 +82,7 @@ Overload this function if your structure has a more efficient way to compute
 `depth` (e.g. if it stores it in a field).
 """
 function depth(tree, acc = 0)
-    if isrootnode(tree)
+    if isroot(tree)
         return acc
     else
         depth(parentnode(tree), acc + 1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -82,7 +82,7 @@ Overload this function if your structure has a more efficient way to compute
 `depth` (e.g. if it stores it in a field).
 """
 function depth(tree, acc = 0)
-    if isroot(tree)
+    if isrootnode(tree)
         return acc
     else
         depth(parentnode(tree), acc + 1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,7 +85,7 @@ function depth(tree, acc = 0)
     if isroot(tree)
         return acc
     else
-        depth(parent(tree), acc + 1)
+        depth(parentnode(tree), acc + 1)
     end
 end
 


### PR DESCRIPTION
fixed #77 

Hi @maltezfaria, I was (again) reading your documentation and found the existing computation of the tree depth seems incorrect, so I came up with this tiny PR. Specifically,
- I added a `isrootnode(H)` to avoid clash with `isroot(H)`
- In `_show`, I changed the computation of depth from `leaves_` to `nodes_`. Does it make more sense to count the depth based on the nested nodes, instead of the final leaves? I might be very wrong here. Anyhow I sent this PR for your review.

With the PR, the following code will somehow show the tree structure of the deepest tree/node. The opacity and number show the level of the corresponding node, while the rectangular shows where the node is.
```julia
using HMatrices, LinearAlgebra, StaticArrays, Plots
using Random

Random.seed!(1234)

const Point3D = SVector{3,Float64}
# sample some points on a sphere
m = 500 #500
X = Y = [Point3D(sin(θ)cos(ϕ),sin(θ)*sin(ϕ),cos(θ)) for (θ,ϕ) in zip(π*rand(m),2π*rand(m))]
function G(x,y) 
  d = norm(x-y) + 1e-8
  1/(4π*d)
end
K = KernelMatrix(G,X,Y)

H = assemble_hmatrix(K;atol=1e-6)

show(H)

# %% get the deepest node
nodes = HMatrices.nodes(H)
depths = map(HMatrices.depth, nodes)
println("max depth: ", maximum(depths))
deepest_node_index = argmax(depths)

deepest_node = nodes[deepest_node_index]

# %% plot the deepest node and all its ancestors
rectangle(w, h, x, y) = Shape(x .+ [0,w,w,0], y .+ [0,0,h,h])
function plot_node_ancestors(node, p=Nothing)
    if p == Nothing
        p = plot(aspect_ratio=:equal)
    end
    level = 1
    while !HMatrices.isrootnode(node) # plot until the root node
        plot!(rectangle(node.rowtree.index_range[end]-node.rowtree.index_range[1],
                    node.coltree.index_range[end]-node.coltree.index_range[1],
                    node.rowtree.index_range[1],
                    node.coltree.index_range[1]), opacity=.5, color=:green, width=1)
        plot!([node.rowtree.index_range[1], node.rowtree.index_range[end]],[node.coltree.index_range[end], node.coltree.index_range[1]],width=1, color=:black)
        annotate!(((node.rowtree.index_range[end]+node.rowtree.index_range[1])*0.5, (node.coltree.index_range[end]+node.coltree.index_range[1])*0.5, text(level, 10, :black)))
        node = HMatrices.parentnode(node)
        level += 1
    end
    return p
end

p = plot(H)
p = plot_node_ancestors(deepest_node, p)
display(p)
```

![plot_51](https://github.com/user-attachments/assets/1ebe7ec7-c05f-4be2-800e-df5b85e806f0)
