### PR TITLE
Error fixes for #81

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HMatrices"
 uuid = "8646bddf-ab1c-4fa7-9c51-ba187d647618"
-version = "0.2.12"
+version = "0.2.13"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -140,9 +140,9 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart, buffer_ = not
                 if K isa KernelMatrix
                   all(j -> iszero(K[first(irange), j]), jrange) &&
                   all(i -> iszero(K[i, first(jrange)]), irange) ||
-                      @warn "aca possibly failed on $irange × $jrange"
+                      @warn "aca possibly failed on $irange × $jrange" maxlog=1
                 else
-                  @warn "aca possibly failed on $irange × $jrange"
+                  @warn "aca possibly failed on $irange × $jrange" maxlog=1
                 end
                 break
             end

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -137,9 +137,13 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart, buffer_ = not
             if isnothing(i)
                 # ran out of candidate rows. Good case: the matrix is zero. Bad
                 # case: aca failed
-                all(j -> iszero(K[first(irange), j]), jrange) &&
-                all(i -> iszero(K[i, first(jrange)]), irange) ||
-                    @warn "aca possibly failed on $irange × $jrange"
+                try
+                  all(j -> iszero(K[first(irange), j]), jrange) &&
+                  all(i -> iszero(K[i, first(jrange)]), irange) ||
+                      @warn "aca possibly failed on $irange × $jrange"
+                catch
+                  @warn "aca possibly failed on $irange × $jrange"
+                end
                 break
             end
         else # δ != 0

--- a/src/compressor.jl
+++ b/src/compressor.jl
@@ -137,11 +137,11 @@ function _aca_partial(K, irange, jrange, atol, rmax, rtol, istart, buffer_ = not
             if isnothing(i)
                 # ran out of candidate rows. Good case: the matrix is zero. Bad
                 # case: aca failed
-                try
+                if K isa KernelMatrix
                   all(j -> iszero(K[first(irange), j]), jrange) &&
                   all(i -> iszero(K[i, first(jrange)]), irange) ||
                       @warn "aca possibly failed on $irange × $jrange"
-                catch
+                else
                   @warn "aca possibly failed on $irange × $jrange"
                 end
                 break

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -221,7 +221,7 @@ Multiplication when the target is a dense matrix. The numbering system in the fo
 function _mul_dense!(C::Base.Matrix, A, B, a)
     Adata = isleaf(A) ? data(A) : A
     Bdata = isleaf(B) ? data(B) : B
-    if Adata isa HMatrix
+    if Adata isa HMatrix || Adata isa Adjoint{Float64, H} where H <: HMatrix
         if Bdata isa Matrix
             _mul131!(C, Adata, Bdata, a)
         elseif Bdata isa RkMatrix
@@ -235,7 +235,7 @@ function _mul_dense!(C::Base.Matrix, A, B, a)
         elseif Bdata isa HMatrix
             _mul113!(C, Adata, Bdata, a)
         end
-    elseif Adata isa RkMatrix
+    elseif Adata isa RkMatrix || Adata isa Adjoint{Float64, H} where H <: RkMatrix
         if Bdata isa Matrix
             _mul121!(C, Adata, Bdata, a)
         elseif Bdata isa RkMatrix

--- a/src/multiplication.jl
+++ b/src/multiplication.jl
@@ -221,7 +221,7 @@ Multiplication when the target is a dense matrix. The numbering system in the fo
 function _mul_dense!(C::Base.Matrix, A, B, a)
     Adata = isleaf(A) ? data(A) : A
     Bdata = isleaf(B) ? data(B) : B
-    if Adata isa HMatrix || Adata isa Adjoint{Float64, H} where H <: HMatrix
+    if Adata isa HMatrix || Adata isa AdjointHMatrix
         if Bdata isa Matrix
             _mul131!(C, Adata, Bdata, a)
         elseif Bdata isa RkMatrix
@@ -235,7 +235,7 @@ function _mul_dense!(C::Base.Matrix, A, B, a)
         elseif Bdata isa HMatrix
             _mul113!(C, Adata, Bdata, a)
         end
-    elseif Adata isa RkMatrix || Adata isa Adjoint{Float64, H} where H <: RkMatrix
+    elseif Adata isa RkMatrix || Adata isa AdjointHMatrix
         if Bdata isa Matrix
             _mul121!(C, Adata, Bdata, a)
         elseif Bdata isa RkMatrix


### PR DESCRIPTION
Hey @maltezfaria---

I got around to taking a look at what's going on here. The following code was hitting two edge cases:
```julia
using StaticArrays, HMatrices

pts = rand(SVector{2,Float64}, 1000)
km  = KernelMatrix((x,y)->Float64(x==y), pts, pts)
hk  = assemble_hmatrix(km; rtol=1e-10)
hkf = cholesky(Hermitian(hk))
```
1. The check in the ACA in the case where no suitable pivot used a `getindex` in the check to decide whether to throw a warning. But since that `getindex` throws an error, that wasn't working. For the moment I've just wrapped it in a try-catch, but I assume you'll have a more thoughtful suggestion about how to do that check.
2. The `_mul_dense!` routine was missing routines for adjoints, so I just added that to the branches on `Adata`. Maybe this one is actually a decent solution? But like above, very happy to do something else if you think it is more suitable. 

Thanks again for the great package!